### PR TITLE
Parse codebase with mcp remote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.cursor/mcp.json


### PR DESCRIPTION
Add `.cursor/mcp.json` to `.gitignore` to prevent committing local MCP server configuration containing a bearer token.

---
<a href="https://cursor.com/background-agent?bcId=bc-03276112-1be5-4ce1-b040-eb6c596cb0ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-03276112-1be5-4ce1-b040-eb6c596cb0ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

